### PR TITLE
On MacOS 15.5 The Clients QT version is not compatible with the lates…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt5
-opencv-contrib-python
+opencv-contrib-python==4.1.2.30
 paramiko
 scp
 pynput


### PR DESCRIPTION
…t opencv version

I was getting the following error:
You might be loading two sets of Qt binaries into the same process. Check that all plugins are compiled against the right Qt binaries. Export DYLD_PRINT_LIBRARIES=1 and check that only one set of binaries are being loaded.

Thus downgraded opencv to a slightly earlier version